### PR TITLE
Parse description field in StateNode

### DIFF
--- a/examples/description.ts
+++ b/examples/description.ts
@@ -1,0 +1,11 @@
+import { createMachine } from "xstate";
+
+export const descriptionMachine = createMachine({
+  initial: "wow",
+  description: "hello!",
+  states: {
+    wow: {
+      description: "WOWZA!",
+    },
+  },
+});

--- a/src/stateNode.ts
+++ b/src/stateNode.ts
@@ -50,6 +50,7 @@ export type StateNodeReturn = {
   states?: GetParserResult<AnyParser<ObjectOfReturn<StateNodeReturn>>>;
   node: t.Node;
   meta?: GetParserResult<typeof StateMeta>;
+  description?: GetParserResult<typeof StringLiteral>;
   tsTypes?: GetParserResult<typeof TsTypes>;
   context?: GetParserResult<typeof Context>;
   data?: GetParserResult<typeof AnyNode>;
@@ -81,6 +82,7 @@ const StateNodeObject: AnyParser<StateNodeReturn> = objectTypeWithKnownKeys(
     context: Context,
     data: AnyNode,
     preserveActionOrder: BooleanLiteral,
+    description: StringLiteral,
   }),
 );
 

--- a/src/toMachineConfig.ts
+++ b/src/toMachineConfig.ts
@@ -83,6 +83,10 @@ const parseStateNode = (
     };
   }
 
+  if (astResult.description) {
+    config.description = astResult.description.value;
+  }
+
   if (astResult.onDone) {
     // @ts-ignore
     config.onDone = getTransitions(astResult.onDone);


### PR DESCRIPTION
This PR resolves #15 by adding the exact diff code supplied by @r-moore in that issue. Also added an `examples` test for the root `description` and a nested `description`.